### PR TITLE
Execute JS Natively

### DIFF
--- a/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
@@ -9,7 +9,7 @@ import spray.json._
 import com.typesafe.webdriver.WebDriverCommands.{WebDriverErrorDetails, Errors, WebDriverError}
 
 /**
- * Runs webdriver command in the context of the JVM ala HtmlUnit.
+ * Runs WebDriver command in the context of the JVM ala HtmlUnit.
  */
 class HtmlUnitWebDriverCommands() extends WebDriverCommands {
   val sessions = TrieMap[String, HtmlPage]()
@@ -62,5 +62,9 @@ class HtmlUnitWebDriverCommands() extends WebDriverCommands {
         }
     }).getOrElse(Future.successful(
       Left(WebDriverError(Errors.NoSuchDriver, WebDriverErrorDetails("Cannot locate sessionId")))))
+  }
+
+  override def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] = {
+    Future.successful(Left(WebDriverError(Errors.UnknownError, WebDriverErrorDetails("Unsupported operation"))))
   }
 }

--- a/src/main/scala/com/typesafe/webdriver/LocalBrowser.scala
+++ b/src/main/scala/com/typesafe/webdriver/LocalBrowser.scala
@@ -70,7 +70,7 @@ object LocalBrowser {
  */
 object PhantomJs {
   def props(host: String = "127.0.0.1", port: Int = 8910)(implicit system: ActorSystem): Props = {
-    val wd = new HttpWebDriverCommands(host, port)
+    val wd = new PhantomJsWebDriverCommands(host, port)
     val args = Some(Seq("phantomjs", s"--webdriver=$host:$port"))
     Props(classOf[LocalBrowser], Session.props(wd), args)
   }

--- a/src/main/scala/com/typesafe/webdriver/PhantomJsWebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/PhantomJsWebDriverCommands.scala
@@ -1,0 +1,21 @@
+package com.typesafe.webdriver
+
+import spray.json.{JsString, JsValue, JsArray}
+import scala.concurrent.Future
+import com.typesafe.webdriver.WebDriverCommands.WebDriverError
+import akka.actor.ActorSystem
+import spray.client.pipelining._
+
+/**
+ * Specialisations for PhantomJs.
+ */
+class PhantomJsWebDriverCommands(host: String, port: Int)(implicit system: ActorSystem)
+  extends HttpWebDriverCommands(host, port) {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  override def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] = {
+    pipeline(Post(s"/session/$sessionId/phantom/execute", s"""{"script":${JsString(s"$script;return result;")},"args":$args}"""))
+      .map(toEitherErrorOrValue)
+  }
+}

--- a/src/main/scala/com/typesafe/webdriver/Session.scala
+++ b/src/main/scala/com/typesafe/webdriver/Session.scala
@@ -1,13 +1,15 @@
 package com.typesafe.webdriver
 
-import akka.actor.{FSM, Props, Actor}
+import akka.actor.{ActorRef, FSM, Props, Actor}
 import com.typesafe.webdriver.Session._
 import scala.Some
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success}
 import spray.can.Http.ConnectionAttemptFailedException
-import spray.json.JsArray
+import spray.json.{JsValue, JsArray}
+import com.typesafe.webdriver.WebDriverCommands.WebDriverError
+import scala.concurrent.Future
 
 /**
  * Browsers maintain sessions for the purposes of our interactions with them. Sessions can be requested to do things
@@ -53,20 +55,36 @@ class Session(wd: WebDriverCommands, sessionConnectTimeout: FiniteDuration)
     case Event(e: ExecuteJs, None) =>
       self forward e
       stay()
+    case Event(e: ExecuteNativeJs, None) =>
+      self forward e
+      stay()
+  }
+
+  private def handleJsExecuteResult(maybeResult: Future[Either[WebDriverError, JsValue]], origSender: ActorRef): Unit = {
+    maybeResult.onComplete {
+      case Success(Right(result)) => origSender ! result
+      case Success(Left(error)) => origSender ! akka.actor.Status.Failure(error.toException)
+      case Failure(t) =>
+        origSender ! akka.actor.Status.Failure(t)
+        log.error("Stopping due to a problem executing commands - {}.", t)
+        stop()
+    }
   }
 
   when(Connected) {
     case Event(e: ExecuteJs, someSessionId@Some(_)) => {
       val origSender = sender
       someSessionId.foreach {
-        wd.executeJs(_, e.script, e.args).onComplete {
-          case Success(Right(result)) => origSender ! result
-          case Success(Left(error)) => origSender ! akka.actor.Status.Failure(error.toException)
-          case Failure(t) =>
-            origSender ! akka.actor.Status.Failure(t)
-            log.error("Stopping due to a problem executing commands - {}.", t)
-            stop()
-        }
+        sessionId =>
+          handleJsExecuteResult(wd.executeJs(sessionId, e.script, e.args), origSender)
+      }
+      stay()
+    }
+    case Event(e: ExecuteNativeJs, someSessionId@Some(_)) => {
+      val origSender = sender
+      someSessionId.foreach {
+        sessionId =>
+          handleJsExecuteResult(wd.executeNativeJs(sessionId, e.script, e.args), origSender)
       }
       stay()
     }
@@ -92,6 +110,15 @@ object Session {
    * @param args the arguments to pass to the script.
    */
   case class ExecuteJs(script: String, args: JsArray)
+
+  /**
+   * Execute JavaScript natively i.e. with access to the features of the underlying browser and/or
+   * JavaScript engine. In the case of PhantomJs, for example, the file system is available along
+   * with the CommonJs/File library.
+   * @param script the js to execute.
+   * @param args the arguments to pass to the script.
+   */
+  case class ExecuteNativeJs(script: String, args: JsArray)
 
   /**
    * A convenience for creating the actor.

--- a/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
@@ -31,6 +31,21 @@ abstract class WebDriverCommands {
    * @return the return value of the script's execution as a json value
    */
   def executeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]]
+
+  /**
+   * Similar to [[com.typesafe.webdriver.WebDriverCommands.executeJs]], this method executes JavaScript code.
+   * However the code is executed directly on the JavaScript engine. What this actually means will depend on
+   * the underlying JavaScript engine. In the case of PhantomJS for example, the full PhantomJS API is available.
+   * For HtmlUnit the underlying JavaScript engine (at this time, Rhino) will be available. The implementation
+   * of this method is entirely optional. If a particular type of Browser does not support it then an error will
+   * be returned.
+   * @param sessionId the session
+   * @param script the script to execute
+   * @param args a json array declaring the arguments to pass to the script
+   * @return the return value of the script's execution as a json value
+   */
+  def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]]
+
 }
 
 object WebDriverCommands {

--- a/src/test/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommandsSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommandsSpec.scala
@@ -8,6 +8,7 @@ import org.specs2.mutable.Specification
 import org.specs2.time.NoDurationConversions
 import org.specs2.matcher.MatchResult
 import com.typesafe.webdriver.WebDriverCommands.{WebDriverErrorDetails, Errors, WebDriverError}
+import java.io.File
 
 @RunWith(classOf[JUnitRunner])
 class HtmlUnitWebDriverCommandsSpec extends Specification with NoDurationConversions {
@@ -84,4 +85,11 @@ class HtmlUnitWebDriverCommandsSpec extends Specification with NoDurationConvers
     Await.result(result, Duration(1, SECONDS)) must beLeft
   }
 
+  "Execute JS natively requesting a commonjs function should fail" in {
+    val result = withSession {
+      (commands, sessionId) =>
+        commands.executeNativeJs(sessionId, "var result = require('fs').separator;", JsArray())
+    }
+    Await.result(result, Duration(1, SECONDS)) must beLeft
+  }
 }

--- a/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
@@ -21,6 +21,10 @@ class LocalBrowserSpec extends Specification {
 
     override def executeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] =
       Future.successful(Right(JsNull))
+
+    override def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] = {
+      throw new UnsupportedOperationException
+    }
   }
 
   "The local browser" should {

--- a/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
@@ -22,6 +22,10 @@ class SessionSpec extends Specification with NoTimeConversions {
 
     def executeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] =
       Future.successful(Right(JsString("hi")))
+
+    override def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] = {
+      throw new UnsupportedOperationException
+    }
   }
 
   "A session" should {

--- a/webdriver-tester/src/main/scala/com/typesafe/webdriver/tester/Main.scala
+++ b/webdriver-tester/src/main/scala/com/typesafe/webdriver/tester/Main.scala
@@ -25,7 +25,7 @@ object Main {
     browser ! LocalBrowser.Startup
     for (
       session <- (browser ? LocalBrowser.CreateSession).mapTo[ActorRef];
-      result <- (session ? Session.ExecuteJs("return arguments[0]", JsArray(JsNumber(999)))).mapTo[JsNumber]
+      result <- (session ? Session.ExecuteNativeJs("return arguments[0]", JsArray(JsNumber(999)))).mapTo[JsNumber]
     ) yield {
       println(result)
 


### PR DESCRIPTION
Incorporation the provision for executing javascript natively on the browser i.e. in such a way that it can make use of the underlying browser specific functionality.
