### PR TITLE
Session capabilities

### DIFF
--- a/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
@@ -16,7 +16,8 @@ class HtmlUnitWebDriverCommands() extends WebDriverCommands {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  override def createSession(): Future[String] = {
+  override def createSession(desiredCapabilities: JsObject = JsObject(),
+                             requiredCapabilities: JsObject = JsObject()): Future[String] = {
     // We like Chrome for no particular reason than its JS is modern. FF may also be a good choice.
     val webClient = new WebClient(BrowserVersion.CHROME)
     val page: HtmlPage = webClient.getPage(WebClient.ABOUT_BLANK)

--- a/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
@@ -16,14 +16,15 @@ class HtmlUnitWebDriverCommands() extends WebDriverCommands {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
+
   override def createSession(desiredCapabilities: JsObject = JsObject(),
-                             requiredCapabilities: JsObject = JsObject()): Future[String] = {
+                             requiredCapabilities: JsObject = JsObject()): Future[(String, Either[WebDriverError, JsValue])] = {
     // We like Chrome for no particular reason than its JS is modern. FF may also be a good choice.
     val webClient = new WebClient(BrowserVersion.CHROME)
     val page: HtmlPage = webClient.getPage(WebClient.ABOUT_BLANK)
     val sessionId = UUID.randomUUID().toString
     sessions.put(sessionId, page)
-    Future.successful(sessionId)
+    Future.successful((sessionId, Right(JsObject())))
   }
 
   override def destroySession(sessionId: String): Unit = {

--- a/src/main/scala/com/typesafe/webdriver/HttpWebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/HttpWebDriverCommands.scala
@@ -78,9 +78,11 @@ class HttpWebDriverCommands(arf: ActorRefFactory, host: String, port: Int) exten
     }
   }
 
+
   override def createSession(desiredCapabilities: JsObject = JsObject(),
-                             requiredCapabilities: JsObject = JsObject()): Future[String] = {
-    pipeline(Post("/session",JsObject("desiredCapabilities"->desiredCapabilities, "requiredCapabilities"->requiredCapabilities).compactPrint)).withFilter(_.status == 0).map(_.sessionId)
+                             requiredCapabilities: JsObject = JsObject()): Future[(String, Either[WebDriverError, JsValue])] = {
+    val capabilities = JsObject("desiredCapabilities"->desiredCapabilities, "requiredCapabilities"->requiredCapabilities).compactPrint
+    pipeline(Post("/session",capabilities)).map(response => (response.sessionId,toEitherErrorOrValue(response)))
   }
 
   override def destroySession(sessionId: String) {

--- a/src/main/scala/com/typesafe/webdriver/HttpWebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/HttpWebDriverCommands.scala
@@ -78,8 +78,9 @@ class HttpWebDriverCommands(arf: ActorRefFactory, host: String, port: Int) exten
     }
   }
 
-  override def createSession(): Future[String] = {
-    pipeline(Post("/session", """{"desiredCapabilities": {}}""")).withFilter(_.status == 0).map(_.sessionId)
+  override def createSession(desiredCapabilities: JsObject = JsObject(),
+                             requiredCapabilities: JsObject = JsObject()): Future[String] = {
+    pipeline(Post("/session",JsObject("desiredCapabilities"->desiredCapabilities, "requiredCapabilities"->requiredCapabilities).compactPrint)).withFilter(_.status == 0).map(_.sessionId)
   }
 
   override def destroySession(sessionId: String) {

--- a/src/main/scala/com/typesafe/webdriver/LocalBrowser.scala
+++ b/src/main/scala/com/typesafe/webdriver/LocalBrowser.scala
@@ -1,6 +1,7 @@
 package com.typesafe.webdriver
 
 import akka.actor._
+import spray.json.JsObject
 import scala.sys.process._
 import com.typesafe.webdriver.LocalBrowser._
 import scala.Some
@@ -27,9 +28,9 @@ class LocalBrowser(sessionProps: Props, maybeArgs: Option[Seq[String]]) extends 
   }
 
   when(Started) {
-    case Event(CreateSession, _) =>
+    case Event(CreateSession(desiredCapabilities, requiredCapabilities), _) =>
       val session = context.actorOf(sessionProps, "session")
-      session ! Session.Connect
+      session ! Session.Connect(desiredCapabilities, requiredCapabilities)
       sender ! session
       stay()
   }
@@ -52,7 +53,7 @@ object LocalBrowser {
   /**
    * Start a new session.
    */
-  case object CreateSession
+  case class CreateSession(desiredCapabilities:JsObject=JsObject(), requiredCapabilities:JsObject=JsObject())
 
 
   // Internal FSM states

--- a/src/main/scala/com/typesafe/webdriver/Session.scala
+++ b/src/main/scala/com/typesafe/webdriver/Session.scala
@@ -25,13 +25,18 @@ class Session(wd: WebDriverCommands, sessionConnectTimeout: FiniteDuration)
 
   when(Uninitialized) {
     case Event(Connect(desiredCapabilities, requiredCapabilities), None) =>
+      val origSender = sender()
       wd.createSession(desiredCapabilities,requiredCapabilities).onComplete {
-        case Success(sessionId) =>
-          self ! SessionCreated(sessionId)
+        case Success((sessionId, Right(capabilities))) =>
+          self.tell(SessionCreated(sessionId, capabilities), origSender)
+        case Success((sessionId, Left(error))) =>
+          log.error("Stopping due to not being able to establish a session with requested capabilities - web driver error - {}.",error)
+          origSender.tell(SessionAborted(sessionId,error), origSender)
+          stop()
         case Failure(_: ConnectionAttemptFailedException) =>
           log.debug("Initial connection attempt failed - retrying shortly.")
           context.system.scheduler.scheduleOnce(500.milliseconds) {
-            self ! Connect
+            self.tell(Connect(desiredCapabilities, requiredCapabilities), origSender)
           }
         case Failure(t) =>
           log.error("Stopping due to not being able to establish a session - exception thrown - {}.", t)
@@ -41,15 +46,21 @@ class Session(wd: WebDriverCommands, sessionConnectTimeout: FiniteDuration)
   }
 
   when(Connecting, stateTimeout = sessionConnectTimeout) {
-    case Event(Connect, None) =>
-      wd.createSession().onComplete {
-        case Success(sessionId) => self ! SessionCreated(sessionId)
+    case Event(Connect(desiredCapabilities, requiredCapabilities), None) =>
+      val origSender = sender()
+      wd.createSession(desiredCapabilities, requiredCapabilities).onComplete {
+        case Success((sessionId, Right(capabilities))) => self.tell(SessionCreated(sessionId, capabilities), origSender)
+        case Success((sessionId, Left(error))) =>
+          log.error("Stopping due to not being able to establish a session with requested capabilities - web driver error - {}.",error)
+          origSender.tell(SessionAborted(sessionId,error), origSender)
+          stop()
         case Failure(t) =>
           log.error("Stopping due to not being able to establish a session - exception thrown - {}.", t)
           stop()
       }
       stay()
-    case Event(SessionCreated(sessionId), None) => goto(Connected) using Some(sessionId)
+    case Event(SessionCreated(sessionId, capabilities), None) =>
+      goto(Connected) using Some(sessionId)
     case Event(StateTimeout, None) =>
       log.error("Stopping due to not being able to establish a session - timed out.")
       stop()
@@ -74,7 +85,7 @@ class Session(wd: WebDriverCommands, sessionConnectTimeout: FiniteDuration)
 
   when(Connected) {
     case Event(e: ExecuteJs, someSessionId@Some(_)) => {
-      val origSender = sender
+      val origSender = sender()
       someSessionId.foreach {
         sessionId =>
           handleJsExecuteResult(wd.executeJs(sessionId, e.script, e.args), origSender)
@@ -82,7 +93,7 @@ class Session(wd: WebDriverCommands, sessionConnectTimeout: FiniteDuration)
       stay()
     }
     case Event(e: ExecuteNativeJs, someSessionId@Some(_)) => {
-      val origSender = sender
+      val origSender = sender()
       someSessionId.foreach {
         sessionId =>
           handleJsExecuteResult(wd.executeNativeJs(sessionId, e.script, e.args), origSender)
@@ -121,6 +132,8 @@ object Session {
    */
   case class ExecuteNativeJs(script: String, args: JsArray)
 
+  case class SessionAborted(sessionId: String, error:WebDriverError)
+
   /**
    * A convenience for creating the actor.
    */
@@ -130,7 +143,7 @@ object Session {
 
   // Internal messages
 
-  private[webdriver] case class SessionCreated(sessionId: String)
+  private[webdriver] case class SessionCreated(sessionId: String, capabilities:JsValue)
 
 
   // Internal FSM states

--- a/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
@@ -14,7 +14,7 @@ abstract class WebDriverCommands {
    * @return the future session id
    */
   def createSession(desiredCapabilities: JsObject = JsObject(),
-                    requiredCapabilities: JsObject = JsObject()): Future[String]
+                    requiredCapabilities: JsObject = JsObject()): Future[(String, Either[WebDriverError, JsValue])]
 
   /**
    * Stop an established session. Performed on a best-effort basis.

--- a/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
@@ -13,7 +13,8 @@ abstract class WebDriverCommands {
    * Start a session
    * @return the future session id
    */
-  def createSession(): Future[String]
+  def createSession(desiredCapabilities: JsObject = JsObject(),
+                    requiredCapabilities: JsObject = JsObject()): Future[String]
 
   /**
    * Stop an established session. Performed on a best-effort basis.

--- a/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
@@ -7,7 +7,7 @@ import akka.testkit._
 import akka.actor.ActorRef
 import java.io.File
 import scala.concurrent.{Promise, Future}
-import spray.json.{JsNull, JsValue, JsArray}
+import spray.json.{JsObject, JsNull, JsValue, JsArray}
 import com.typesafe.webdriver.WebDriverCommands.WebDriverError
 
 // Note that this test will only run on Unix style environments where the "rm" command is available.
@@ -15,7 +15,7 @@ import com.typesafe.webdriver.WebDriverCommands.WebDriverError
 class LocalBrowserSpec extends Specification {
 
   object TestWebDriverCommands extends WebDriverCommands {
-    override def createSession(): Future[String] = Promise.successful("123").future
+    override def createSession(desiredCapabilities:JsObject=JsObject(), requiredCapabilities:JsObject=JsObject()): Future[String] = Promise.successful("123").future
 
     override def destroySession(sessionId: String) {}
 
@@ -55,7 +55,7 @@ class LocalBrowserSpec extends Specification {
 
       localBrowser ! LocalBrowser.Startup
 
-      localBrowser ! LocalBrowser.CreateSession
+      localBrowser ! LocalBrowser.CreateSession()
       expectMsgClass(classOf[ActorRef])
     }
   }

--- a/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
@@ -15,7 +15,7 @@ import com.typesafe.webdriver.WebDriverCommands.WebDriverError
 class LocalBrowserSpec extends Specification {
 
   object TestWebDriverCommands extends WebDriverCommands {
-    override def createSession(desiredCapabilities:JsObject=JsObject(), requiredCapabilities:JsObject=JsObject()): Future[String] = Promise.successful("123").future
+    override def createSession(desiredCapabilities:JsObject=JsObject(), requiredCapabilities:JsObject=JsObject()): Future[(String, Either[WebDriverError, JsValue])] = Promise.successful(("123",Right(JsObject()))).future
 
     override def destroySession(sessionId: String) {}
 

--- a/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
@@ -1,5 +1,6 @@
 package com.typesafe.webdriver
 
+import com.typesafe.webdriver.Session.SessionAborted
 import org.junit.runner.RunWith
 import org.specs2.runner.JUnitRunner
 import org.specs2.mutable.Specification
@@ -7,16 +8,16 @@ import scala.concurrent.{Await, Promise, Future}
 import scala.concurrent.duration._
 import org.specs2.time.NoTimeConversions
 import spray.json.{JsObject, JsString, JsValue, JsArray}
-import com.typesafe.webdriver.WebDriverCommands.WebDriverError
+import com.typesafe.webdriver.WebDriverCommands.{WebDriverErrorDetails, WebDriverError}
 
 @RunWith(classOf[JUnitRunner])
 class SessionSpec extends Specification with NoTimeConversions {
 
   class TestWebDriverCommands extends WebDriverCommands {
-    val p = Promise[String]()
+    val p = Promise[(String, Either[WebDriverError, JsValue])]()
     val f = p.future
 
-    def createSession(desiredCapabilities:JsObject=JsObject(), requiredCapabilities:JsObject=JsObject()): Future[String] = f
+    def createSession(desiredCapabilities:JsObject=JsObject(), requiredCapabilities:JsObject=JsObject()): Future[(String, Either[WebDriverError, JsValue])] = f
 
     def destroySession(sessionId: String) {}
 
@@ -29,6 +30,21 @@ class SessionSpec extends Specification with NoTimeConversions {
   }
 
   "A session" should {
+    "tell its creator that it couldn't acquire the required capabilites" in new TestActorSystem {
+      val wd = new TestWebDriverCommands
+      val error = WebDriverError(-1, WebDriverErrorDetails("error"))
+      val sid = "123"
+
+      val session = system.actorOf(Session.props(wd))
+
+      session ! Session.Connect()
+
+      wd.p.success((sid, Left(error)))
+
+      Await.ready(wd.f, 2.seconds)
+
+      expectMsg(SessionAborted(sid, error))
+    }
     "requeue requests while in a connecting state" in new TestActorSystem {
 
       val wd = new TestWebDriverCommands
@@ -39,7 +55,7 @@ class SessionSpec extends Specification with NoTimeConversions {
 
       session ! Session.ExecuteJs("", JsArray())
 
-      wd.p.success("123")
+      wd.p.success(("123", Right(JsObject())))
 
       Await.ready(wd.f, 2.seconds)
 

--- a/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
@@ -6,7 +6,7 @@ import org.specs2.mutable.Specification
 import scala.concurrent.{Await, Promise, Future}
 import scala.concurrent.duration._
 import org.specs2.time.NoTimeConversions
-import spray.json.{JsString, JsValue, JsArray}
+import spray.json.{JsObject, JsString, JsValue, JsArray}
 import com.typesafe.webdriver.WebDriverCommands.WebDriverError
 
 @RunWith(classOf[JUnitRunner])
@@ -16,7 +16,7 @@ class SessionSpec extends Specification with NoTimeConversions {
     val p = Promise[String]()
     val f = p.future
 
-    def createSession(): Future[String] = f
+    def createSession(desiredCapabilities:JsObject=JsObject(), requiredCapabilities:JsObject=JsObject()): Future[String] = f
 
     def destroySession(sessionId: String) {}
 
@@ -35,7 +35,7 @@ class SessionSpec extends Specification with NoTimeConversions {
 
       val session = system.actorOf(Session.props(wd))
 
-      session ! Session.Connect
+      session ! Session.Connect()
 
       session ! Session.ExecuteJs("", JsArray())
 


### PR DESCRIPTION
Implements capabilities requests and requirements when creating the session.

Per https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session the session creation accepts two optional objects : desiredCapabilities and requiredCapabilities.

If the required capabilities cannot be met, the actor which sent LocalBrowser.CreateSession(desiredCapabilities, requiredCapabilities) is informed that the session creation was aborted and provided the error from the driver.