### PR TITLE
Implements navigating a given session to another url

### DIFF
--- a/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
@@ -69,4 +69,17 @@ class HtmlUnitWebDriverCommands() extends WebDriverCommands {
   override def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] = {
     Future.successful(Left(WebDriverError(Errors.UnknownError, WebDriverErrorDetails("Unsupported operation"))))
   }
+
+  override def navigateTo(sessionId: String, url: String): Future[Either[WebDriverError, Unit]] = {
+    val webClient = new WebClient(BrowserVersion.CHROME)
+    val navigationResult: Either[WebDriverError, Unit] = try {
+      sessions.put(sessionId, webClient.getPage(url))
+      Right(())
+    } catch {
+      case t: Throwable =>
+        t.printStackTrace()
+        Left(WebDriverError(Errors.UnknownError, WebDriverErrorDetails(t.getMessage)))
+    }
+    Future.successful(navigationResult)
+  }
 }

--- a/src/main/scala/com/typesafe/webdriver/Session.scala
+++ b/src/main/scala/com/typesafe/webdriver/Session.scala
@@ -70,12 +70,29 @@ class Session(wd: WebDriverCommands, sessionConnectTimeout: FiniteDuration)
     case Event(e: ExecuteNativeJs, None) =>
       self forward e
       stay()
+    case evt@Event(NavigateTo(_), None) =>
+      self forward evt.event
+      stay()
   }
 
   private def handleJsExecuteResult(maybeResult: Future[Either[WebDriverError, JsValue]], origSender: ActorRef): Unit = {
     maybeResult.onComplete {
       case Success(Right(result)) => origSender ! result
       case Success(Left(error)) => origSender ! akka.actor.Status.Failure(error.toException)
+      case Failure(t) =>
+        origSender ! akka.actor.Status.Failure(t)
+        log.error("Stopping due to a problem executing commands - {}.", t)
+        stop()
+    }
+  }
+
+  private def handleUnitResult(maybeResult: Future[Either[WebDriverError, Unit]], origSender: ActorRef): Unit = {
+    maybeResult.onComplete {
+      case Success(Right(result)) =>
+        origSender ! Done
+      case Success(Left(error)) =>
+        log.debug("Unable to execute command - {}.", error)
+        origSender ! akka.actor.Status.Failure(error.toException)
       case Failure(t) =>
         origSender ! akka.actor.Status.Failure(t)
         log.error("Stopping due to a problem executing commands - {}.", t)
@@ -97,6 +114,14 @@ class Session(wd: WebDriverCommands, sessionConnectTimeout: FiniteDuration)
       someSessionId.foreach {
         sessionId =>
           handleJsExecuteResult(wd.executeNativeJs(sessionId, e.script, e.args), origSender)
+      }
+      stay()
+    }
+    case Event(NavigateTo(url), someSessionId@Some(_)) => {
+      val origSender = sender()
+      someSessionId.foreach {
+        sessionId =>
+          handleUnitResult(wd.navigateTo(sessionId, url), origSender)
       }
       stay()
     }
@@ -133,6 +158,19 @@ object Session {
   case class ExecuteNativeJs(script: String, args: JsArray)
 
   case class SessionAborted(sessionId: String, error:WebDriverError)
+
+  /**
+   * A command without return value has been completed.
+   */
+  case object Done
+
+  /**
+   * Ask the browser to navigate to a different URL
+   *
+   * This command does not return a value but will signal its completion with a Done message.
+   * @param url the target url
+   */
+  case class NavigateTo(url: String)
 
   /**
    * A convenience for creating the actor.

--- a/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
@@ -47,6 +47,16 @@ abstract class WebDriverCommands {
    */
   def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]]
 
+  /**
+   * Navigate to a new URL.
+   * POST /session/:sessionId/url
+   * @see https://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/url
+   * @param sessionId the session
+   * @param url the url to navigate to
+   * @return
+   */
+  def navigateTo(sessionId:String, url:String): Future[Either[WebDriverError, Unit]]
+
 }
 
 object WebDriverCommands {

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,3 @@
+akka {
+  loglevel = "ERROR"
+}

--- a/src/test/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommandsSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommandsSpec.scala
@@ -1,6 +1,7 @@
 package com.typesafe.webdriver
 
 import org.junit.runner.RunWith
+import org.specs2.execute.{Result, AsResult}
 import org.specs2.runner.JUnitRunner
 import spray.json._
 import scala.concurrent.{Await, Future}
@@ -8,7 +9,6 @@ import org.specs2.mutable.Specification
 import org.specs2.time.NoDurationConversions
 import org.specs2.matcher.MatchResult
 import com.typesafe.webdriver.WebDriverCommands.{WebDriverErrorDetails, Errors, WebDriverError}
-import java.io.File
 
 @RunWith(classOf[JUnitRunner])
 class HtmlUnitWebDriverCommandsSpec extends Specification with NoDurationConversions {
@@ -16,7 +16,7 @@ class HtmlUnitWebDriverCommandsSpec extends Specification with NoDurationConvers
   import scala.concurrent.ExecutionContext.Implicits.global
   import scala.concurrent.duration._
 
-  def withSession(block: (WebDriverCommands, (String, Either[WebDriverError, JsValue])) => Future[Either[WebDriverError, JsValue]]): Future[Either[WebDriverError, JsValue]] = {
+  def withSession[T](block: (WebDriverCommands, (String, Either[WebDriverError, JsValue])) => Future[Either[WebDriverError, T]]): Future[Either[WebDriverError, T]] = {
     val commands = new HtmlUnitWebDriverCommands()
     val maybeSession = commands.createSession().map { case (sessionId, createResult) =>
         val result = block(commands, (sessionId, createResult))
@@ -94,5 +94,15 @@ class HtmlUnitWebDriverCommandsSpec extends Specification with NoDurationConvers
         commands.executeNativeJs(id, "var result = require('fs').separator;", JsArray())
     }
     Await.result(result, Duration(1, SECONDS)) must beLeft
+  }
+
+  "Navigate to a new page should work" in new WithStubServer {
+    val baseUrl = s"http://localhost:$port/"
+    val result = withSession {
+      (commands, sessionId) =>
+        val (id, _) = sessionId
+        commands.navigateTo(id, baseUrl)
+    }
+    Await.result(result, Duration(10, SECONDS)) must beRight(())
   }
 }

--- a/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
@@ -25,6 +25,9 @@ class LocalBrowserSpec extends Specification {
     override def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] = {
       throw new UnsupportedOperationException
     }
+
+    override def navigateTo(sessionId: String, url: String): Future[Either[WebDriverError, Unit]] =
+      throw new UnsupportedOperationException
   }
 
   "The local browser" should {

--- a/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
@@ -27,6 +27,9 @@ class SessionSpec extends Specification with NoTimeConversions {
     override def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] = {
       throw new UnsupportedOperationException
     }
+
+    override def navigateTo(sessionId: String, url: String): Future[Either[WebDriverError, Unit]] =
+      Future.successful(Right(Unit))
   }
 
   "A session" should {
@@ -60,6 +63,23 @@ class SessionSpec extends Specification with NoTimeConversions {
       Await.ready(wd.f, 2.seconds)
 
       expectMsg(JsString("hi"))
+
+    }
+    "be able to navigate to an url" in new TestActorSystem {
+
+      val wd = new TestWebDriverCommands
+
+      val session = system.actorOf(Session.props(wd))
+
+      session ! Session.Connect()
+
+      session ! Session.NavigateTo("http://www.example.com")
+
+      wd.p.success(("123", Right(JsObject())))
+
+      Await.ready(wd.f, 2.seconds)
+
+      expectMsg(Session.Done)
 
     }
   }

--- a/src/test/scala/com/typesafe/webdriver/StubServer.scala
+++ b/src/test/scala/com/typesafe/webdriver/StubServer.scala
@@ -1,0 +1,97 @@
+package com.typesafe.webdriver
+
+import java.net.ServerSocket
+
+import akka.actor._
+import akka.io.IO
+import akka.util.Timeout
+import akka.pattern.ask
+import org.specs2.execute.{Result, AsResult}
+import org.specs2.mutable.Around
+import org.specs2.specification.Scope
+import org.specs2.time.NoDurationConversions
+import spray.can.Http
+import spray.http._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class DefaultStubHandler extends Actor with ActorLogging {
+  def receive = {
+    case _: Http.Connected =>
+      sender ! Http.Register(self)
+    case HttpRequest(HttpMethods.GET, Uri.Path("/"), _, _, _) =>
+      sender() ! HttpResponse(entity = HttpEntity(MediaTypes.`text/html`, "ok"), status = 200)
+    case evt: HttpRequest =>
+      sender() ! HttpResponse(status = 404)
+  }
+}
+
+abstract class WithStubServer(handlerProps: Props = Props[DefaultStubHandler]) extends Around with Scope with NoDurationConversions {
+  lazy val port = StubServer.randomPort
+
+  override def around[T: AsResult](t: => T): Result = {
+    implicit val system = ActorSystem()
+    implicit val timeout = Timeout(Duration(10, MINUTES))
+    val handler = system.actorOf(StubServer.props(port, handlerProps), name = "server")
+
+    val eventualStarted = handler ? StubServer.Start
+    val eventualResult = eventualStarted.map { _ =>
+      val effectiveResult = AsResult.effectively(t)
+      handler ! StubServer.Stop
+      system.awaitTermination()
+      effectiveResult
+    }
+
+    Await.result(eventualResult, Duration(10, MINUTES))
+  }
+}
+
+class StubServer(port: Int, handlerProps: Props) extends Actor with Stash with ActorLogging {
+  implicit val system = context.system
+  private val handler = system.actorOf(handlerProps, name = "handler")
+
+  def receive: Receive = {
+    case StubServer.Start =>
+      log.info(s"starting stub http server on port $port")
+      IO(Http) ! Http.Bind(handler, interface = "localhost", port = this.port)
+      context.become(starting(sender()), discardOld = true)
+  }
+
+  def starting(client: ActorRef): Receive = {
+    case Http.Bound(addr) =>
+      context.become(running(sender()), discardOld = true)
+      unstashAll()
+      client !()
+    case _ => stash()
+  }
+
+  def running(listener: ActorRef): Receive = {
+    case StubServer.Stop =>
+      listener ! Http.Unbind
+      context.become(stopping, discardOld = true)
+    case _ => ()
+  }
+
+  def stopping: Receive = {
+    case Http.Unbound =>
+      system.shutdown()
+  }
+}
+
+object StubServer {
+  def randomPort: Int = {
+    val s = new ServerSocket(0)
+    val port = s.getLocalPort
+    s.close()
+    if (port == 0) randomPort else port
+  }
+
+  def props(port: Int, handlerProps: Props) = Props(new StubServer(port, handlerProps))
+
+  case object Stop
+
+  case object Start
+
+}


### PR DESCRIPTION
Reference documentation is at https://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/url

In the JsonWireProtocol, this command doesn't return any values, I have therefore introduced a `Done` object in the session protocol which represents the completion of a "returnless" command. 

I have implemented the corresponding command in WebDriverCommands and its various implementations and test cases where it made sense. Implementing the test case for HtmlUnitWebDriverCommands required me to create a stub HTTP server and a specs2 helper to start and stop it around a test case. The stub HTTP server is based on spray-can which was already a dependency of the project.