### PR TITLE
Implements capturing a screenshot

### DIFF
--- a/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
@@ -69,4 +69,8 @@ class HtmlUnitWebDriverCommands() extends WebDriverCommands {
   override def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] = {
     Future.successful(Left(WebDriverError(Errors.UnknownError, WebDriverErrorDetails("Unsupported operation"))))
   }
+
+  override def screenshot(sessionId: String): Future[Either[WebDriverError, JsValue]] = {
+    Future.successful(Left(WebDriverError(Errors.UnknownError, WebDriverErrorDetails("Unsupported operation"))))
+  }
 }

--- a/src/main/scala/com/typesafe/webdriver/HttpWebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/HttpWebDriverCommands.scala
@@ -97,4 +97,9 @@ class HttpWebDriverCommands(arf: ActorRefFactory, host: String, port: Int) exten
   override def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] = {
     Future.successful(Left(WebDriverError(Errors.UnknownError, WebDriverErrorDetails("Unsupported operation"))))
   }
+
+  override def screenshot(sessionId: String): Future[Either[WebDriverError, JsValue]] = {
+    pipeline(Get(s"/session/$sessionId/screenshot"))
+      .map(toEitherErrorOrValue)
+  }
 }

--- a/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
@@ -47,6 +47,15 @@ abstract class WebDriverCommands {
    */
   def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]]
 
+  /**
+   * Take a screenshot of the current window.
+   * GET /session/:sessionId/screenshot
+   * @see https://code.google.com/p/selenium/wiki/JsonWireProtocol#GET_/session/:sessionId/screenshot
+   * @param sessionId the session
+   * @return
+   */
+  def screenshot(sessionId:String): Future[Either[WebDriverError, JsValue]]
+
 }
 
 object WebDriverCommands {

--- a/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
@@ -25,6 +25,10 @@ class LocalBrowserSpec extends Specification {
     override def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] = {
       throw new UnsupportedOperationException
     }
+
+    override def screenshot(sessionId: String): Future[Either[WebDriverError, JsValue]] = {
+      throw new UnsupportedOperationException
+    }
   }
 
   "The local browser" should {

--- a/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
@@ -27,6 +27,10 @@ class SessionSpec extends Specification with NoTimeConversions {
     override def executeNativeJs(sessionId: String, script: String, args: JsArray): Future[Either[WebDriverError, JsValue]] = {
       throw new UnsupportedOperationException
     }
+
+    override def screenshot(sessionId: String): Future[Either[WebDriverError, JsValue]] = {
+      Future.successful(Right(JsString("base64EncodedPNG")))
+    }
   }
 
   "A session" should {
@@ -61,6 +65,21 @@ class SessionSpec extends Specification with NoTimeConversions {
 
       expectMsg(JsString("hi"))
 
+    }
+    "capture a screenshot and return the base64 encoded string representing the PNG to the client" in new TestActorSystem {
+
+      val wd = new TestWebDriverCommands
+
+      val session = system.actorOf(Session.props(wd))
+
+      session ! Session.Connect()
+
+      wd.p.success(("123", Right(JsObject())))
+      Await.ready(wd.f, 2.seconds)
+
+      session ! Session.ScreenShot
+
+      expectMsg(JsString("base64EncodedPNG"))
     }
   }
 }


### PR DESCRIPTION
Reference documentation is at https://code.google.com/p/selenium/wiki/JsonWireProtocol#GET_/session/:sessionId/screenshot

The webdriver API returns a base64 encoded string of the PNG file generated, the current implementation leaves the decoding to the client.