### PR TITLE
Refactor WebDriverCommands#createSession result type

### DIFF
--- a/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/HtmlUnitWebDriverCommands.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import com.gargoylesoftware.htmlunit.html.HtmlPage
 import scala.concurrent.Future
 import spray.json._
-import com.typesafe.webdriver.WebDriverCommands.{WebDriverErrorDetails, Errors, WebDriverError}
+import com.typesafe.webdriver.WebDriverCommands.{WebDriverSession, WebDriverErrorDetails, Errors, WebDriverError}
 
 /**
  * Runs WebDriver command in the context of the JVM ala HtmlUnit.
@@ -18,13 +18,13 @@ class HtmlUnitWebDriverCommands() extends WebDriverCommands {
 
 
   override def createSession(desiredCapabilities: JsObject = JsObject(),
-                             requiredCapabilities: JsObject = JsObject()): Future[(String, Either[WebDriverError, JsValue])] = {
+                             requiredCapabilities: JsObject = JsObject()): Future[Either[WebDriverError, WebDriverSession]] = {
     // We like Chrome for no particular reason than its JS is modern. FF may also be a good choice.
     val webClient = new WebClient(BrowserVersion.CHROME)
     val page: HtmlPage = webClient.getPage(WebClient.ABOUT_BLANK)
     val sessionId = UUID.randomUUID().toString
     sessions.put(sessionId, page)
-    Future.successful((sessionId, Right(JsObject())))
+    Future.successful( Right(WebDriverSession(sessionId, JsObject())))
   }
 
   override def destroySession(sessionId: String): Unit = {

--- a/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
+++ b/src/main/scala/com/typesafe/webdriver/WebDriverCommands.scala
@@ -2,7 +2,7 @@ package com.typesafe.webdriver
 
 import scala.concurrent.Future
 import spray.json._
-import com.typesafe.webdriver.WebDriverCommands.WebDriverError
+import com.typesafe.webdriver.WebDriverCommands.{WebDriverSession, WebDriverError}
 
 /**
  * Encapsulates all of the request/reply commands that can be sent via the WebDriver protocol. All commands perform
@@ -14,7 +14,7 @@ abstract class WebDriverCommands {
    * @return the future session id
    */
   def createSession(desiredCapabilities: JsObject = JsObject(),
-                    requiredCapabilities: JsObject = JsObject()): Future[(String, Either[WebDriverError, JsValue])]
+                    requiredCapabilities: JsObject = JsObject()): Future[Either[WebDriverError, WebDriverSession]]
 
   /**
    * Stop an established session. Performed on a best-effort basis.
@@ -129,6 +129,8 @@ object WebDriverCommands {
     /** Target provided for a move action is out of bounds. */
     val MoveTargetOutOfBounds = 34
   }
+
+  private[webdriver] case class WebDriverSession(id:String, capabilities:JsObject)
 
   /**
    * An error returned by WebDriver.

--- a/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
@@ -8,14 +8,15 @@ import akka.actor.ActorRef
 import java.io.File
 import scala.concurrent.{Promise, Future}
 import spray.json.{JsObject, JsNull, JsValue, JsArray}
-import com.typesafe.webdriver.WebDriverCommands.WebDriverError
+import com.typesafe.webdriver.WebDriverCommands.{WebDriverSession, WebDriverError}
 
 // Note that this test will only run on Unix style environments where the "rm" command is available.
 @RunWith(classOf[JUnitRunner])
 class LocalBrowserSpec extends Specification {
 
   object TestWebDriverCommands extends WebDriverCommands {
-    override def createSession(desiredCapabilities:JsObject=JsObject(), requiredCapabilities:JsObject=JsObject()): Future[(String, Either[WebDriverError, JsValue])] = Promise.successful(("123",Right(JsObject()))).future
+    override def createSession(desiredCapabilities:JsObject=JsObject(), requiredCapabilities:JsObject=JsObject()): Future[Either[WebDriverError, WebDriverSession]] =
+      Promise.successful(Right(WebDriverSession("123",JsObject()))).future
 
     override def destroySession(sessionId: String) {}
 

--- a/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/SessionSpec.scala
@@ -8,16 +8,16 @@ import scala.concurrent.{Await, Promise, Future}
 import scala.concurrent.duration._
 import org.specs2.time.NoTimeConversions
 import spray.json.{JsObject, JsString, JsValue, JsArray}
-import com.typesafe.webdriver.WebDriverCommands.{WebDriverErrorDetails, WebDriverError}
+import com.typesafe.webdriver.WebDriverCommands.{WebDriverSession, WebDriverErrorDetails, WebDriverError}
 
 @RunWith(classOf[JUnitRunner])
 class SessionSpec extends Specification with NoTimeConversions {
 
   class TestWebDriverCommands extends WebDriverCommands {
-    val p = Promise[(String, Either[WebDriverError, JsValue])]()
+    val p = Promise[Either[WebDriverError, WebDriverSession]]()
     val f = p.future
 
-    def createSession(desiredCapabilities:JsObject=JsObject(), requiredCapabilities:JsObject=JsObject()): Future[(String, Either[WebDriverError, JsValue])] = f
+    def createSession(desiredCapabilities:JsObject=JsObject(), requiredCapabilities:JsObject=JsObject()): Future[Either[WebDriverError, WebDriverSession]] = f
 
     def destroySession(sessionId: String) {}
 
@@ -39,11 +39,11 @@ class SessionSpec extends Specification with NoTimeConversions {
 
       session ! Session.Connect()
 
-      wd.p.success((sid, Left(error)))
+      wd.p.success(Left(error))
 
       Await.ready(wd.f, 2.seconds)
 
-      expectMsg(SessionAborted(sid, error))
+      expectMsg(SessionAborted(error))
     }
     "requeue requests while in a connecting state" in new TestActorSystem {
 
@@ -55,7 +55,7 @@ class SessionSpec extends Specification with NoTimeConversions {
 
       session ! Session.ExecuteJs("", JsArray())
 
-      wd.p.success(("123", Right(JsObject())))
+      wd.p.success(Right(WebDriverSession("123",JsObject())))
 
       Await.ready(wd.f, 2.seconds)
 


### PR DESCRIPTION
Extract a case class representing session creation success which contains the created sessionId and the capabilities listed by the underlying driver, in case the session creation failed, do not return a sessionId.