### PR TITLE
Fix wedriver-tester project

### DIFF
--- a/webdriver-tester/src/main/scala/com/typesafe/webdriver/tester/Main.scala
+++ b/webdriver-tester/src/main/scala/com/typesafe/webdriver/tester/Main.scala
@@ -22,7 +22,7 @@ object Main {
     val browser = system.actorOf(PhantomJs.props(system), "localBrowser")
     browser ! LocalBrowser.Startup
     for (
-      session <- (browser ? LocalBrowser.CreateSession).mapTo[ActorRef];
+      session <- (browser ? LocalBrowser.CreateSession()).mapTo[ActorRef];
       result <- (session ? Session.ExecuteNativeJs("return arguments[0]", JsArray(JsNumber(999)))).mapTo[JsNumber]
     ) yield {
       println(result)


### PR DESCRIPTION
PR #7 introduced the possibility to pass desired and required session
capabilities with empty json objects as the default. The webdriver-tester
project was not properly upgraded at the time.
