### PR TITLE
Upgrade spray-client dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.3.9",
-  "io.spray" % "spray-client" % "1.3.1",
+  "io.spray" %% "spray-client" % "1.3.2",
   "io.spray" %% "spray-json" % "1.3.2",
   "net.sourceforge.htmlunit" % "htmlunit" % "2.15",
   "org.specs2" %% "specs2-core" % "3.4" % "test",


### PR DESCRIPTION
In #13, spray-json was upgraded to 1.3.2 leading to the following error
`java.lang.NoSuchMethodError:
spray.json.JsonParser$.apply(Ljava/lang/String;)Lspray/json/JsValue;` when using
the phantomJs driver.

This commit upgrades spray-client to 1.3.2 to avoid this error.
