### PR TITLE
Fix #12 : monitor native process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.3.9",
-  "io.spray" % "spray-client" % "1.3.1",
+  "io.spray" %% "spray-client" % "1.3.2",
   "io.spray" %% "spray-json" % "1.3.2",
   "net.sourceforge.htmlunit" % "htmlunit" % "2.15",
   "org.specs2" %% "specs2-core" % "3.4" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -4,16 +4,20 @@ name := "webdriver"
 scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor" % "2.3.9",
+  "com.typesafe.akka" %% "akka-actor" % "2.3.11",
+  "com.typesafe.akka" %% "akka-contrib-extra" % "1.18.0",
   "io.spray" %% "spray-client" % "1.3.2",
   "io.spray" %% "spray-json" % "1.3.2",
   "net.sourceforge.htmlunit" % "htmlunit" % "2.15",
   "org.specs2" %% "specs2-core" % "3.4" % "test",
   "junit" % "junit" % "4.11" % "test",
-  "com.typesafe.akka" %% "akka-testkit" % "2.3.9" % "test"
+  "com.typesafe.akka" %% "akka-testkit" % "2.3.11" % "test"
 )
 // Required by specs2 to get scalaz-stream
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
+
+//Required by sbt even though it is included in activator
+resolvers += "typesafe-bintray" at "https://repo.typesafe.com/typesafe/releases/"
 
 lazy val root = project in file(".")
 

--- a/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
+++ b/src/test/scala/com/typesafe/webdriver/LocalBrowserSpec.scala
@@ -2,9 +2,10 @@ package com.typesafe.webdriver
 
 import org.specs2.mutable.Specification
 import akka.testkit._
-import akka.actor.ActorRef
+import akka.actor.{Props, ActorRef}
 import java.io.File
 import scala.concurrent.{Promise, Future}
+import scala.collection.immutable
 import spray.json.{JsObject, JsNull, JsValue, JsArray}
 import com.typesafe.webdriver.WebDriverCommands.{WebDriverSession, WebDriverError}
 
@@ -37,18 +38,12 @@ class LocalBrowserSpec extends Specification {
       val f = File.createTempFile("LocalBrowserSpec", "")
       f.deleteOnExit()
 
-      val localBrowser = TestFSMRef(new LocalBrowser(Session.props(TestWebDriverCommands), Some(Seq("rm", f.getCanonicalPath))))
+      val localBrowser = TestFSMRef(new LocalBrowser(Session.props(TestWebDriverCommands), Some(immutable.Seq("rm", f.getCanonicalPath))))
 
       val probe = TestProbe()
       probe watch localBrowser
 
-      localBrowser.stateName must_== LocalBrowser.Uninitialized
-
       localBrowser ! LocalBrowser.Startup
-
-      localBrowser.stateName must_== LocalBrowser.Started
-
-      localBrowser.stop()
 
       probe.expectTerminated(localBrowser)
 


### PR DESCRIPTION
The LocalBrowser actor should stop when the underlying native process dies 

Based on advice by @hseeberger and @huntc,  I used akka-contrib-extra's BlockingProcess instead of a plain scala process to start the process and get the death notification 

both stdout and stderr  of the native process are redirected to the LocalBrowser's logger

Regards
jean
