### PR TITLE
Travis migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 jdk: openjdk6
 language: scala
 script: sbt test
+sudo: false


### PR DESCRIPTION
The travis builds raise a warning that the project's build are running on the legacy infrastructure. This PR intends to apply the migration process described in http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade
